### PR TITLE
input: hall: Report SW_LID instead of SW_FLIP

### DIFF
--- a/drivers/input/hall.c
+++ b/drivers/input/hall.c
@@ -493,7 +493,7 @@ static int hall_probe(struct platform_device *pdev)
 #ifdef CONFIG_V_HALL_FOLDING
 	ddata->event_val = SW_FOLDING;
 #else
-	ddata->event_val = SW_FLIP;
+	ddata->event_val = SW_LID;
 #endif
 	input_set_capability(input, EV_SW, ddata->event_val);
 


### PR DESCRIPTION
* Android expects SW_LID for lid events.

Change-Id: Iebffbabdbb3748eec4f887ebd227c67adf01d8ef
Signed-off-by: Roman Birg <roman@cyngn.com>